### PR TITLE
Fixes issue #4 - Incorrect timestamps. Adds formatting for SRT

### DIFF
--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -53,7 +53,7 @@ impl Transcript {
                     i + 1,
                     transcript
                         + format!(
-                            "{i}\n{} --> {}\n{}\n",
+                            "\n{i}\n{} --> {}\n{}\n",
                             format_timestamp(fragment.start, true, ","),
                             format_timestamp(fragment.stop, true, ","),
                             fragment.text.trim().replace("-->", "->")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,7 +48,7 @@ pub async fn download_file(url: &str, path: &str) {
 
 pub fn format_timestamp(seconds: i64, always_include_hours: bool, decimal_marker: &str) -> String {
     assert!(seconds >= 0, "non-negative timestamp expected");
-    let mut milliseconds = seconds * 1000;
+    let mut milliseconds = seconds * 10;
 
     let hours = div_floor(milliseconds, 3_600_000);
     milliseconds -= hours * 3_600_000;


### PR DESCRIPTION
I didn't dig too deep fixing this.

Changing the 1000 to 10 fixes the bad offset. Doesn't seem like you're getting seconds from whisper, so the math was all wonk.

Also added a leading newline writing out each caption entry, without it SRTs will import as one very long caption, at least in KDEnlive.

Thanks for this simple app, it was very easy to get working over all. 