### PR TITLE
Fixes download URL

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -89,7 +89,7 @@ impl Model {
 
         download_file(
             &format!(
-                "https://huggingface.co/datasets/ggerganov/whisper.cpp/resolve/main/ggml-{}.bin",
+                "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{}.bin",
                 self.size
             ),
             path.to_str().unwrap(),


### PR DESCRIPTION
The URL currently in use requests the user to log in. Due to this, any model downloaded is instead a file with a message to please log in.

Removing /datasets from the URL resolves this issue and allows downloading datasets as intended.
