### PR TITLE
feat: support 16bit WAV files with hound in case ffmpeg is not installed on the user system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@
 **/*.rs.bk
 
 .DS_Store
+
+# transcriptions outputs
+*.vtt
+*.txt
+*.srt
+
+# inputs files
+*.wav
+*.mp3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "hound"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d13cdbd5dbb29f9c88095bbdc2590c9cba0d0a1269b983fef6b2cdd7e9f4db1"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
@@ -1562,6 +1562,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "hound",
  "indicatif",
  "num",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num = "0.4.1"
 dirs = "5.0.1"
 anyhow = "1.0.75"
 indicatif = "0.17.6"
+hound = "3.5.1"
 whisper-rs = "0.8.0"
 futures-util = "0.3.28"
 uuid = { version = "1.4.1", features = ["v4"] }
@@ -28,3 +29,4 @@ clap = { version = "4.4.3", features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
 reqwest = { version = "0.11.20", features = ["blocking", "stream"] }
 audrey = { version = "0.3.0", default-features = false, features = ["wav"] }
+

--- a/src/ffmpeg_decoder.rs
+++ b/src/ffmpeg_decoder.rs
@@ -42,6 +42,28 @@ fn use_ffmpeg<P: AsRef<Path>>(input_path: P) -> Result<Vec<i16>> {
 }
 
 pub fn read_file<P: AsRef<Path>>(audio_file_path: P) -> Result<Vec<f32>> {
-    let audio_buf = use_ffmpeg(&audio_file_path)?;
-    Ok(whisper_rs::convert_integer_to_float_audio(&audio_buf))
+    if is_ffmpeg_available() {
+        println!("ffmpeg is available");
+        let audio_buf = use_ffmpeg(&audio_file_path)?;
+        Ok(whisper_rs::convert_integer_to_float_audio(&audio_buf))
+    } else {
+        println!("ffmpeg not found. Using hound decoder as fallback");
+        let mut reader = hound::WavReader::open(audio_file_path)?;
+    
+        // Convert i16 samples to f32 and normalize to [-1.0, 1.0]
+        let samples: Vec<f32> = reader
+            .samples::<i16>()
+            .map(|s| s.unwrap() as f32 / std::i16::MAX as f32)
+            .collect();
+        
+        Ok(samples)
+    }
+
+}
+
+fn is_ffmpeg_available() -> bool {
+    match std::process::Command::new("ffmpeg").arg("-version").status() {
+        Ok(status) => status.success(),
+        Err(_) => false,
+    }
 }

--- a/src/ffmpeg_decoder.rs
+++ b/src/ffmpeg_decoder.rs
@@ -49,20 +49,22 @@ pub fn read_file<P: AsRef<Path>>(audio_file_path: P) -> Result<Vec<f32>> {
     } else {
         println!("ffmpeg not found. Using hound decoder as fallback");
         let mut reader = hound::WavReader::open(audio_file_path)?;
-    
+
         // Convert i16 samples to f32 and normalize to [-1.0, 1.0]
         let samples: Vec<f32> = reader
             .samples::<i16>()
             .map(|s| s.unwrap() as f32 / std::i16::MAX as f32)
             .collect();
-        
+
         Ok(samples)
     }
-
 }
 
 fn is_ffmpeg_available() -> bool {
-    match std::process::Command::new("ffmpeg").arg("-version").status() {
+    match std::process::Command::new("ffmpeg")
+        .arg("-version")
+        .status()
+    {
         Ok(status) => status.success(),
         Err(_) => false,
     }


### PR DESCRIPTION
Before this commit users must have ffmpeg installed on their systems. For some use cases supporting 16-bit WAV files is enough, therefore we add a fallback using hound 
crate. 

Bonus: Added the output files as part of .gitignore
